### PR TITLE
Fixed property name to minimalTlsVersion on CosmosDBDatabaseAccountCr…

### DIFF
--- a/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2022-11-15/examples/CosmosDBDatabaseAccountCreateMax.json
+++ b/specification/cosmos-db/resource-manager/Microsoft.DocumentDB/stable/2022-11-15/examples/CosmosDBDatabaseAccountCreateMax.json
@@ -227,7 +227,7 @@
               "generationTime": "2021-03-12T22:05:09Z"
             }
           },
-          "minimumTlsVersion": "Tls12"
+          "minimalTlsVersion": "Tls12"
         },
         "systemData": {
           "createdAt": "2021-03-12T22:05:09Z"


### PR DESCRIPTION
Changed property name from minimumTlsVersion to minimalTlsVersion on the example CosmosDBDatabaseAccountCreateMax.json
